### PR TITLE
readme requirements and installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ For METAS UncLib see
 ## Requirements
 - numpy
 - pythonnet
-- on *macOS*: [Mono .NET framework](https://www.mono-project.com)
+- on *Linux* and *macOS*: [Mono .NET framework](https://www.mono-project.com)
 
 ## Installation
 


### PR DESCRIPTION
- note that Mono is required for macOS
- required packages
- pip installation