### PR TITLE
python-native unc_budget rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ For METAS UncLib see
 - numpy
 - pythonnet
 - on *Linux* and *macOS*: [Mono .NET framework](https://www.mono-project.com)
+- optional: pandas (for unc_budget rendering)
 
 ## Installation
 

--- a/metas_unclib.py
+++ b/metas_unclib.py
@@ -231,7 +231,7 @@ def _input_id_desc(id=None, desc=None):
 		desc2 = ''
 	return id2, desc2
 
-def unc_budget(unc_item):
+def unc_budget(unc_item, format=None, name=None, infos=None):
 	tree = _LinPropUncBudget.ComputeTreeUncBudget(unc_item.net_object)
 
 	data = np.zeros((len(tree) + 1, 2))


### PR DESCRIPTION
Since the .NET GUI doesn't work on newer Macs (and will never*), the unc_budget is now rendered in python.

If pandas is installed, it will be returned as a pd.DataFrame, otherwise it will be printed in plaintext and returned as np.array and dict with the labels.

I couldn't implement the *format=None, name=None, infos=None* keywords, since I didn't understand their behaviour (and couldn't test it on my mac...)

* https://github.com/pleonex/tinke/issues/80#issuecomment-698529146